### PR TITLE
Fix exception with react-navigation v1.0.0-beta9 when using enhance() on a nested navigator

### DIFF
--- a/src/enhanceNavigator.js
+++ b/src/enhanceNavigator.js
@@ -61,19 +61,13 @@ export default function enhanceNavigator<T: *>(
     _fireStateListeners = state => this._listeners.forEach(cb => cb(state));
 
     render() {
-      let topLevelNavProps;
-      // We can only set onNavigationStateChange on top level navigators
-      // with react-navigation v1.0.0-beta.9 otherwise we get an exception
+      let props = this.props;
+
       if (!this.props.navigation || !this.props.navigation.state) {
-        topLevelNavProps = { onNavigationStateChange: this._handleNavigationStateChange}
+        props = { ...props, onNavigationStateChange: this._handleNavigationStateChange };
       }
 
-      return (
-        <Navigator
-          {...this.props}
-          {...topLevelNavProps}
-        />
-      );
+      return <Navigator {...props} />;
     }
   };
 }

--- a/src/enhanceNavigator.js
+++ b/src/enhanceNavigator.js
@@ -61,14 +61,17 @@ export default function enhanceNavigator<T: *>(
     _fireStateListeners = state => this._listeners.forEach(cb => cb(state));
 
     render() {
+      let topLevelNavProps;
+      // We can only set onNavigationStateChange on top level navigators
+      // with react-navigation v1.0.0-beta.9 otherwise we get an exception
+      if (!this.props.navigation || !this.props.navigation.state) {
+        topLevelNavProps = { onNavigationStateChange: this._handleNavigationStateChange}
+      }
+
       return (
         <Navigator
           {...this.props}
-          onNavigationStateChange={
-            this.props.navigation && this.props.navigation.state
-              ? undefined
-              : this._handleNavigationStateChange
-          }
+          {...topLevelNavProps}
         />
       );
     }


### PR DESCRIPTION
Hi there,

I was getting an exception when using enhance() on a nested navigator with react-navigation v1.0.0-beta9.
Even though you took care of passing `onNavigationStateChange: undefined` for non top level navigators, the invariant in https://github.com/react-community/react-navigation/blob/03698c9a69baae606cd3aaa0de5c17c87f057edf/src/createNavigationContainer.js#L82-L88 still sees the `onNavigationStateChange` key present and complains.

So here is a small fix to avoid that.

Thanks for putting together this experiment. 