### PR TITLE
Rewrite the goBack

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,21 @@ class SettingsScreen extends Component {
   }
 }
 ```
+
+### `navigation.forceUpdate`
+Force all scene update because of a change in language or theme.
+
+**Example:**
+```js
+class SettingsScreen extends Component {
+
+  changeTheme = () => {
+    ...
+    this.props.navigation.forceUpdate()
+  };
+  
+  render() {
+    ...
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -139,3 +139,26 @@ class SettingsScreen extends Component {
 ```
 
 If there's no parent navigator, this method will return `undefined`.
+
+### `navigation.goBack`
+Rewrite goBack to support routeName and step。
+
+**Example:**
+```js
+class SettingsScreen extends Component {
+
+  onBack = () => {
+    const { goBack } = this.props.navigation
+    // Return to the prev page
+    goBack()
+    // Return to the prev prev page
+    goBack(2)
+    // Return to the routeName is Login's page，If history does not have a Login, it is reset to Login
+    goBack('Login')
+  };
+  
+  render() {
+    ...
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "eslint-import-resolver-babel-module": "^3.0.0",
-    "hoist-non-react-statics": "^1.2.0",
-    "shallowequal": "^0.2.2"
+    "events": "^1.1.1",
+    "hoist-non-react-statics": "^2.3.1",
+    "shallowequal": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-eslint": "^7.2.2",
     "eslint": "^3.19.0",
     "eslint-config-prettier": "^1.7.0",
+    "eslint-import-resolver-babel-module": "^3.0.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-flowtype": "^2.32.1",
     "eslint-plugin-import": "^2.2.0",
@@ -26,7 +27,6 @@
     "react-navigation": "^1.0.0-beta.12"
   },
   "dependencies": {
-    "eslint-import-resolver-babel-module": "^3.0.0",
     "events": "^1.1.1",
     "hoist-non-react-statics": "^2.3.1",
     "shallowequal": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettier": "^1.2.2",
     "react": "^15.5.4",
     "react-native": "^0.43.4",
-    "react-navigation": "^1.0.0-beta.8"
+    "react-navigation": "^1.0.0-beta.12"
   },
   "dependencies": {
     "eslint-import-resolver-babel-module": "^3.0.0",

--- a/src/enhanceNavigator.js
+++ b/src/enhanceNavigator.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { PureComponent, PropTypes } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import type { NavigationState } from 'react-navigation/src/TypeDefinition';
 
 type NavigationStateListener = NavigationState => void;

--- a/src/enhanceScreen.js
+++ b/src/enhanceScreen.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import hoist from 'hoist-non-react-statics';
 import shallowEqual from 'shallowequal';
 import { NavigationActions } from 'react-navigation';


### PR DESCRIPTION
Rewrite goBack to support routeName and step。

**Example:**
```js
class SettingsScreen extends Component {

  onBack = () => {
    const { goBack } = this.props.navigation
    // Return to the prev page
    goBack()
    // Return to the prev prev page
    goBack(2)
    // Return to the routeName is Login's page，If history does not have a Login, it is reset to Login
    goBack('Login')
  };
  
  render() {
    ...
  }
}
```

![example](http://ovqlwefo0.bkt.gdipper.com/example.gif)
Need to wait for this [PR](https://github.com/react-community/react-navigation/pull/2520) to pass through to resolve the animation exception.